### PR TITLE
Fix optional fields in dynamic form

### DIFF
--- a/src/utils/strapiToFormConfig.ts
+++ b/src/utils/strapiToFormConfig.ts
@@ -200,8 +200,13 @@ export function strapiToFormConfig(strapiSchema: any) {
     if (!zodField) {
       zodField = z.any();
     }
+    // Ensure optionality matches the Strapi schema
+    if (attr.required !== true) {
+      // Calling optional multiple times is safe
+      zodField = zodField.optional();
+    }
     zodShape[name] = zodField;
-    defaultValues[name] = attr.default ?? '';
+    defaultValues[name] = attr.default ?? (attr.required ? '' : undefined);
 
     fieldsConfig.push({
       name,


### PR DESCRIPTION
## Summary
- ensure non-required fields are treated as optional when generating Zod schema
- keep optional fields' default values undefined

## Testing
- `npx --yes jest` *(fails: Jest unable to parse ES modules)*
- `npx next lint` *(fails: needed packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6842e5a0600c8325b74e8aec0920bc5b