### PR TITLE
Fix useConfirm hook import

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./Providers";
-import { ConfirmDialog } from "@k2600x/design-system";
+import { ConfirmDialog } from "@/components/ui";
 import { Toaster } from "sonner";
 import { ThemeScript } from "./ThemeScript";
 

--- a/src/components/operation-tags/OperationTagsManager.tsx
+++ b/src/components/operation-tags/OperationTagsManager.tsx
@@ -8,7 +8,7 @@ import { Button, Input } from "@k2600x/design-system";
 import { PencilIcon, Trash2Icon, PlusIcon } from "lucide-react";
 import { useStrapiCollection } from "@/hooks/useStrapiCollection";
 import { useStrapiUpdateMutation } from "@/hooks/useStrapiUpdateMutation";
-import { useConfirm } from "@k2600x/design-system";
+import { useConfirm } from "@/hooks/useConfirm";
 import useStrapiDelete from "@/hooks/useStrapiDelete";
 import {
   Dialog,

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  Button,
+} from "@k2600x/design-system";
+import React from "react";
+import { useConfirmStore } from "@/hooks/useConfirm";
+
+export function ConfirmDialog() {
+  const {
+    open,
+    title,
+    description,
+    confirmText,
+    cancelText,
+    onConfirm,
+    onCancel,
+    hide,
+    extraContent,
+  } = useConfirmStore();
+
+  const [extraState, setExtraState] = React.useState<any>(undefined);
+
+  React.useEffect(() => {
+    setExtraState(undefined);
+  }, [open]);
+
+  const handleConfirm = () => {
+    if (onConfirm) onConfirm(extraState);
+    hide();
+  };
+
+  const handleCancel = () => {
+    if (onCancel) onCancel();
+    hide();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={hide}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        {extraContent && (
+          <div className="mb-2">
+            {React.cloneElement(extraContent as React.ReactElement, {
+              onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+                setExtraState((e.target as HTMLInputElement).checked ?? undefined),
+            })}
+          </div>
+        )}
+        <DialogFooter className="flex justify-end space-x-2">
+          <Button variant="outline" onClick={handleCancel}>
+            {cancelText}
+          </Button>
+          <Button onClick={handleConfirm}>{confirmText}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConfirmDialog";

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand";
+import { ReactNode } from "react";
+
+interface ConfirmDialogState {
+  open: boolean;
+  title?: string;
+  description?: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm?: (options?: any) => void;
+  onCancel?: () => void;
+  extraContent?: React.ReactNode;
+  extraState?: any;
+
+  show: (options: {
+    title: string;
+    description: string;
+    confirmText?: string;
+    cancelText?: string;
+    onConfirm?: (options?: any) => void;
+    onCancel?: () => void;
+    extraContent?: React.ReactNode;
+    extraState?: any;
+  }) => void;
+
+  hide: () => void;
+}
+
+export const useConfirmStore = create<ConfirmDialogState>((set) => ({
+  open: false,
+  title: "",
+  description: "",
+  confirmText: "Confirmar",
+  cancelText: "Cancelar",
+  onConfirm: undefined,
+  onCancel: undefined,
+  extraContent: undefined,
+  extraState: undefined,
+
+  show: (options) =>
+    set({
+      open: true,
+      ...options,
+      extraContent: options.extraContent,
+      extraState: options.extraState,
+    }),
+
+  hide: () =>
+    set({
+      open: false,
+      title: "",
+      description: "",
+      confirmText: "Confirmar",
+      cancelText: "Cancelar",
+      onConfirm: undefined,
+      onCancel: undefined,
+      extraContent: undefined,
+      extraState: undefined,
+    }),
+}));
+
+export const useConfirm = () => {
+  const { show } = useConfirmStore();
+  return show;
+};


### PR DESCRIPTION
## Summary
- implement local `useConfirm` hook and dialog
- replace imports with new local ConfirmDialog

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: unable to fetch fonts due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6842f944eab48325904949638133a8c7