### PR TITLE
Fix ConfirmDialog TypeScript props

### DIFF
--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -48,9 +48,9 @@ export function ConfirmDialog() {
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
-        {extraContent && (
+        {React.isValidElement(extraContent) && (
           <div className="mb-2">
-            {React.cloneElement(extraContent as React.ReactElement, {
+            {React.cloneElement(extraContent as React.ReactElement<any>, {
               onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
                 setExtraState((e.target as HTMLInputElement).checked ?? undefined),
             })}


### PR DESCRIPTION
## Summary
- check that extraContent is a valid element before cloning
- cast extraContent with `ReactElement<any>` so `onChange` prop is allowed

## Testing
- `npx tsc --noEmit`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843045ae49c8325aa1faa0cbf4b61bc