### PR TITLE
Fix relation label and boolean fields in forms

### DIFF
--- a/src/components/admin/StrapiRelationField.tsx
+++ b/src/components/admin/StrapiRelationField.tsx
@@ -29,7 +29,7 @@ interface StrapiRelationFieldProps {
   isMulti?: boolean;
   disabled?: boolean;
   placeholder?: string;
-  displayField?: string; // Field to show as label (default: displayName or name)
+  displayField?: string; // Field used as label (default: "name")
   apiUrl?: string; // Override for fetching
 }
 
@@ -40,7 +40,7 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
   isMulti = false,
   disabled = false,
   placeholder = "(Selecciona...)",
-  displayField = "displayName",
+  displayField = "name",
   apiUrl,
 }) => {
   const [options, setOptions] = useState<RelationOption[]>([]);

--- a/src/hooks/useFormFactory.tsx
+++ b/src/hooks/useFormFactory.tsx
@@ -431,7 +431,38 @@ export function useFormFactory(
 
  
 
-      // --- DEFAULT: STRING, TEXT, BOOLEAN, ETC. ---
+      // --- BOOLEAN FIELDS ---
+      if (cfg.type === "boolean") {
+        return (
+          <div key={cfg.name} style={{ display: "flex", flexDirection: "column", gap: 2, height: '100%' }}>
+            <label htmlFor={cfg.name} style={{ fontWeight: 500, marginBottom: 2 }}>
+              {cfg.label}
+              {cfg.required && <span style={{ color: "#d32f2f", marginLeft: 4 }}>*</span>}
+            </label>
+            <Controller
+              name={cfg.name}
+              control={control}
+              render={({ field }) => (
+                <Comp
+                  {...(cfg.props || {})}
+                  checked={!!field.value}
+                  onCheckedChange={field.onChange}
+                  disabled={cfg.disabled}
+                  id={cfg.name}
+                />
+              )}
+            />
+            {cfg.description && (
+              <span style={{ fontSize: 12, color: "#666", marginTop: 2 }}>{cfg.description}</span>
+            )}
+            {errorMsg && (
+              <span style={{ color: "#d32f2f", fontSize: 13, marginTop: 2 }}>{errorMsg}</span>
+            )}
+          </div>
+        );
+      }
+
+      // --- DEFAULT: STRING, TEXT, ETC. ---
 
       return (
 

--- a/src/utils/strapiToFormConfig.ts
+++ b/src/utils/strapiToFormConfig.ts
@@ -206,7 +206,11 @@ export function strapiToFormConfig(strapiSchema: any) {
       zodField = zodField.optional();
     }
     zodShape[name] = zodField;
-    defaultValues[name] = attr.default ?? (attr.required ? '' : undefined);
+    if (attr.type === 'boolean') {
+      defaultValues[name] = attr.default ?? (attr.required ? false : undefined);
+    } else {
+      defaultValues[name] = attr.default ?? (attr.required ? '' : undefined);
+    }
 
     fieldsConfig.push({
       name,


### PR DESCRIPTION
## Summary
- show related name by default in `StrapiRelationField`
- handle boolean fields with `Controller`
- set boolean defaults correctly

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430f9899808325bac8f3a5f597d212