### PR TITLE
Bump design system

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-react',
+    '@babel/preset-typescript'
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/preset-typescript": "^7.27.0",
         "@headlessui/react": "^2.2.0",
         "@hookform/resolvers": "^5.0.1",
-        "@k2600x/design-system": "^1.7.4",
+        "@k2600x/design-system": "^1.8.0",
         "@minoru/react-dnd-treeview": "^3.5.0",
         "@radix-ui/react-checkbox": "^1.1.4",
         "@radix-ui/react-dialog": "^1.1.6",
@@ -2800,9 +2800,10 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@k2600x/design-system": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@k2600x/design-system/-/design-system-1.7.4.tgz",
-      "integrity": "sha512-Lxpd6k549tT0/edpMd6zz5tr2rFOtQmgbkiyCKrEjbjfs7+ZLkvpcGpgE33rUs7k2V5bIsDTdiXcy2puQER+/Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@k2600x/design-system/-/design-system-1.8.0.tgz",
+      "integrity": "sha512-ikIqvBT7H9QKp0F3gdIiP1lXPOi61+2y23H3SjEFwY8AAArB9moTMmfjhsxwHfQhK/ODAhf4pfxA31YKCLaFXw==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-dialog": "^1.1.14",
@@ -2818,7 +2819,6 @@
         "lucide-react": "^0.511.0",
         "react-select": "^5.10.1",
         "tailwind-merge": "^3.3.0",
-        "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.4"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@babel/preset-typescript": "^7.27.0",
     "@headlessui/react": "^2.2.0",
     "@hookform/resolvers": "^5.0.1",
-    "@k2600x/design-system": "^1.7.4",
+    "@k2600x/design-system": "^1.8.0",
     "@minoru/react-dnd-treeview": "^3.5.0",
     "@radix-ui/react-checkbox": "^1.1.4",
     "@radix-ui/react-dialog": "^1.1.6",


### PR DESCRIPTION
## Summary
- bump `@k2600x/design-system` to 1.8.0
- add `babel.config.js` for Jest

## Testing
- `npm install`
- `CI=1 npx jest`

------
https://chatgpt.com/codex/tasks/task_e_684319fcf0a48325b6e7c123e3577b33