### PR TITLE
Show documentId as label

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -73,14 +73,16 @@ export default function AdminPage() {
     if (!selectedCollection) return;
     setLoading(true);
     try {
-      let payload = values;
+      let payload = normalizeRelationsForUpdate(values, schemas[selectedCollection]);
+      // Remove documentId/id fields so they are not sent in the payload
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { documentId: _docId, id: _id, ...rest } = payload;
+      payload = rest;
       if (selectedRecord) {
-        // Update: use documentId for PUT, normalize relations
-        payload = normalizeRelationsForUpdate(values, schemas[selectedCollection]);
+        // Update: use documentId for PUT
         await updateRecord(selectedRecord.documentId, payload);
       } else {
-        // Create: normalize relations
-        payload = normalizeRelationsForUpdate(values, schemas[selectedCollection]);
+        // Create
         await createRecord(payload);
       }
       setShowForm(false);

--- a/src/components/admin/RecordFormDialog.tsx
+++ b/src/components/admin/RecordFormDialog.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, Button } from "@k2600x/design-system";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, Button, Label } from "@k2600x/design-system";
 import { DynamicStrapiForm } from "@/components/dynamic-form/DynamicStrapiForm";
 
 /**
@@ -57,11 +57,13 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
             hideSubmitButton={true} // Hide the form's own submit button
           />
         </div>
-        <DialogFooter>
-          <Button 
-            onClick={handleFooterSubmit} 
-            disabled={loading}
-          >
+        <DialogFooter className="flex flex-col gap-2">
+          {record?.documentId && (
+            <Label disabled className="opacity-70 text-sm">
+              {record.documentId}
+            </Label>
+          )}
+          <Button onClick={handleFooterSubmit} disabled={loading}>
             {record ? "Update" : "Create"}
           </Button>
         </DialogFooter>

--- a/src/components/dynamic-form/DynamicStrapiForm.tsx
+++ b/src/components/dynamic-form/DynamicStrapiForm.tsx
@@ -36,15 +36,33 @@ export const DynamicStrapiForm = React.forwardRef<
 
   // Move all hooks to the top level, before any early returns
   //const relationOptionsMap = useRelationOptions([], schemas);
-  const { schema: zodSchema, defaultValues, fieldsConfig } = React.useMemo(
-    () => strapiToFormConfig(schema),
-    [schema]
+  const {
+    schema: baseSchema,
+    defaultValues: baseDefaults,
+    fieldsConfig: baseFields,
+  } = React.useMemo(() => strapiToFormConfig(schema), [schema]);
+
+  // Remove documentId from form fields and validation schema
+  const zodSchema = React.useMemo(
+    () => (baseSchema && "omit" in baseSchema ? baseSchema.omit({ documentId: true }) : baseSchema),
+    [baseSchema]
   );
+  const fieldsConfig = React.useMemo(
+    () => baseFields.filter((f) => f.name !== "documentId"),
+    [baseFields]
+  );
+  const defaultValues = React.useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { documentId: _docId, ...rest } = baseDefaults || {};
+    return rest;
+  }, [baseDefaults]);
 
   // PATCH: If document is present (edit mode), override defaultValues with document
   const mergedDefaultValues = React.useMemo(() => {
     if (!document) return defaultValues;
-    return { ...defaultValues, ...document };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { documentId: _docId, ...restDoc } = document;
+    return { ...defaultValues, ...restDoc };
   }, [defaultValues, document]);
 
   const formFactory = useFormFactory(


### PR DESCRIPTION
## Summary
- display documentId in `RecordFormDialog` footer as a disabled label
- preserve payload fields but strip documentId before requests
- keep dynamic form defaults without documentId

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684319c2b2e483259641642eb36e40d8