### PR TITLE
Fix relation option labels

### DIFF
--- a/src/components/admin/StrapiRelationField.tsx
+++ b/src/components/admin/StrapiRelationField.tsx
@@ -71,7 +71,11 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
         const json = await res.json();
         const items = json.data || [];
         const opts = items.map((item: any) => ({
-          label: item.attributes?.[displayField] || item.attributes?.name || item.id,
+          label:
+            item.attributes?.[displayField] ||
+            item.attributes?.displayName ||
+            item.attributes?.name ||
+            item.id,
           value: item.id,
           link: `/admin/${collection}/${item.id}`,
         }));


### PR DESCRIPTION
## Summary
- ensure relation dropdowns show `displayName` or `name` before falling back to id

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684321d23f10832592388aaea70e67c9