### PR TITLE
Add Jest tests for Strapi helpers

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,7 @@ module.exports = {
   transform: {
     '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
   },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@babel/preset-react": "^7.26.3",
@@ -56,6 +57,7 @@
     "babel-jest": "^29.7.0",
     "eslint": "^9",
     "eslint-config-next": "15.2.0",
+    "jest": "^29.7.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/src/hooks/useStrapiGetOne.test.ts
+++ b/src/hooks/useStrapiGetOne.test.ts
@@ -1,0 +1,26 @@
+import { useStrapiGetOne } from './useStrapiGetOne';
+
+let capturedQueryFn: any;
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (config: any) => {
+    capturedQueryFn = config.queryFn;
+    return { data: undefined, error: undefined, isLoading: false, refetch: jest.fn() };
+  }
+}));
+
+jest.mock('../services/strapi', () => ({
+  post: jest.fn(() => Promise.resolve({ data: {} }))
+}));
+import strapi from '../services/strapi';
+
+beforeEach(() => {
+  (strapi.post as jest.Mock).mockClear();
+});
+
+test('useStrapiGetOne uses documentId when provided', async () => {
+  useStrapiGetOne('items', '5', { documentId: '99' });
+  await capturedQueryFn();
+  expect(strapi.post).toHaveBeenCalled();
+  const body = (strapi.post as jest.Mock).mock.calls[0][0];
+  expect(body.id).toBe('99');
+});

--- a/src/hooks/useStrapiMutationBase.test.ts
+++ b/src/hooks/useStrapiMutationBase.test.ts
@@ -1,0 +1,32 @@
+import useStrapiMutationBase from './useStrapiMutationBase';
+
+jest.mock('@tanstack/react-query', () => ({
+  useMutation: (config: any) => ({ mutateAsync: config.mutationFn }),
+  useQueryClient: () => ({ invalidateQueries: jest.fn() }),
+}));
+
+describe('useStrapiMutationBase', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve(new Response(JSON.stringify({ data: {} }), { status: 200 }))) as any;
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockClear();
+  });
+
+  test('uses documentId as id field when provided', async () => {
+    const hook = useStrapiMutationBase('items', { method: 'PUT' });
+    await hook.mutateAsync({ documentId: '123', name: 'test' });
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.id).toBe('123');
+    expect(body.method).toBe('PUT');
+    expect(body.collection).toBe('items');
+  });
+
+  test('uses id field when provided directly', async () => {
+    const hook = useStrapiMutationBase('items', { method: 'PUT' });
+    await hook.mutateAsync({ id: '45', name: 'other' });
+    const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+    expect(body.id).toBe('45');
+  });
+});

--- a/src/services/strapi.test.ts
+++ b/src/services/strapi.test.ts
@@ -1,0 +1,16 @@
+import { strapiRequest } from './strapi';
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve(new Response(JSON.stringify({ success: true }), { status: 200 }))) as any;
+});
+
+afterEach(() => {
+  (global.fetch as jest.Mock).mockClear();
+});
+
+test('strapiRequest posts to /api/strapi with given body', async () => {
+  await strapiRequest({ method: 'GET', collection: 'users' });
+  expect(global.fetch).toHaveBeenCalledWith('/api/strapi', expect.objectContaining({ method: 'POST' }));
+  const body = JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body);
+  expect(body.collection).toBe('users');
+});


### PR DESCRIPTION
## Summary
- add jest moduleNameMapper for path aliases
- add `test` script and jest dev dependency
- create tests for `strapiRequest` helper
- test update mutation logic uses `documentId`
- test `useStrapiGetOne` uses `documentId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843250ac8188325960b9bca87a7106f