### PR TITLE
Fix relation labels and add dirty state

### DIFF
--- a/src/components/admin/RecordFormDialog.tsx
+++ b/src/components/admin/RecordFormDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, Button, Label } from "@k2600x/design-system";
+import { useConfirm } from "@/hooks/useConfirm";
 import { DynamicStrapiForm } from "@/components/dynamic-form/DynamicStrapiForm";
 
 /**
@@ -32,7 +33,8 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
   title = "Edit Record",
 }) => {
   // Create a ref to store the form submit function
-  const formRef = useRef<{ submitForm: () => void }>(null);
+  const formRef = useRef<{ submitForm: () => void; isDirty: () => boolean }>(null);
+  const confirm = useConfirm();
 
   // Function to handle form submission from the footer button
   const handleFooterSubmit = () => {
@@ -41,8 +43,22 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
     }
   };
 
+  const handleOpenChange = (val: boolean) => {
+    if (!val) {
+      if (formRef.current?.isDirty()) {
+        confirm({
+          title: "¿Cerrar sin guardar?",
+          description: "Hay cambios sin guardar.",
+          onConfirm: onClose,
+        });
+        return;
+      }
+    }
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="min-w-[800px] w-[1200px] max-w-[95vw] max-h-[95vh] overflow-hidden flex flex-col">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -63,7 +79,10 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
               {record.documentId}
             </Label>
           )}
-          <Button onClick={handleFooterSubmit} disabled={loading}>
+          <Button
+            onClick={handleFooterSubmit}
+            disabled={loading || !formRef.current?.isDirty()}
+          >
             {record ? "Update" : "Create"}
           </Button>
         </DialogFooter>

--- a/src/components/admin/StrapiRelationField.tsx
+++ b/src/components/admin/StrapiRelationField.tsx
@@ -98,12 +98,12 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
   }, [open, collection, apiUrl, displayField]);
 
   // Normalize incoming value to id array and extract fallback labels
-  const normalizedArray = extractIds(value);
+  const normalizedArray = extractIds(value).map((v) => String(v));
   const fallbackLabels = extractLabels(value, displayField);
 
   const selectedOptions = isMulti
-    ? options.filter((opt) => normalizedArray.includes(opt.value))
-    : options.find((opt) => normalizedArray.includes(opt.value));
+    ? options.filter((opt) => normalizedArray.includes(String(opt.value)))
+    : options.find((opt) => normalizedArray.includes(String(opt.value)));
 
   // For MultiSelect: options must have id:number, defaultValue:number[]
   // Map options to required shape for MultiSelect
@@ -200,7 +200,16 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
             onChange={onChange}
           />
         ) : (
-          <Select value={selectValue} onValueChange={onChange}>
+          <Select
+            value={selectValue}
+            onValueChange={(val) => {
+              const parsed =
+                options.length > 0 && typeof options[0].value === "number"
+                  ? Number(val)
+                  : val;
+              onChange(parsed);
+            }}
+          >
             <SelectTrigger>{/* placeholder handled above */}</SelectTrigger>
             <SelectContent>
               {options.map((opt) => (

--- a/src/components/dynamic-form/DynamicStrapiForm.tsx
+++ b/src/components/dynamic-form/DynamicStrapiForm.tsx
@@ -18,7 +18,7 @@ export interface DynamicStrapiFormProps {
 }
 
 export const DynamicStrapiForm = React.forwardRef<
-  { submitForm: () => void },
+  { submitForm: () => void; isDirty: () => boolean },
   DynamicStrapiFormProps
 >((
   {
@@ -89,6 +89,7 @@ export const DynamicStrapiForm = React.forwardRef<
     submitForm: () => {
       formFactory.form.handleSubmit(handleSubmit)();
     },
+    isDirty: () => formFactory.form.formState.isDirty,
   }));
 
   // Render fields in a 3-column grid

--- a/src/utils/__tests__/relationHelpers.test.ts
+++ b/src/utils/__tests__/relationHelpers.test.ts
@@ -18,4 +18,11 @@ describe("relation helpers", () => {
     expect(extractLabels(null)).toEqual([]);
     expect(extractLabels([1, 2])).toEqual(["1", "2"]);
   });
+
+  test("string ids match numeric option values", () => {
+    const options = [{ label: "One", value: 1 }];
+    const normalized = extractIds("1").map((v) => String(v));
+    const selected = options.find((o) => normalized.includes(String(o.value)));
+    expect(selected?.label).toBe("One");
+  });
 });


### PR DESCRIPTION
## Summary
- fix type mismatch when matching relation options
- convert Select values to numbers when appropriate
- expose dirty state from DynamicStrapiForm
- prompt to confirm closing RecordFormDialog with unsaved changes
- disable update button until changes are made
- test relationHelpers for mixed id types

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684337e630e883259702c89b3aae4ebe