### PR TITLE
Fix MultiSelect types and build

### DIFF
--- a/src/components/admin/StrapiRelationField.tsx
+++ b/src/components/admin/StrapiRelationField.tsx
@@ -90,7 +90,8 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
   }, [collection, apiUrl, displayField]);
 
   // Normalize incoming value to an array of ids
-  const normalizedArray = extractIds(value).map((v) => String(v));
+  const normalizedIds = extractIds(value);
+  const normalizedArray = normalizedIds.map((v) => String(v));
 
   const selectedOptions = isMulti
     ? options.filter((opt) => normalizedArray.includes(String(opt.value)))
@@ -99,12 +100,10 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
   // For MultiSelect: options must have id:number, defaultValue:number[]
   // Map options to required shape for MultiSelect
   const multiSelectOptions = options.map((opt) => ({
-    ...opt,
     id: typeof opt.value === "number" ? opt.value : Number(opt.value),
+    label: opt.label,
   }));
-  const multiSelectDefaultValue = normalizedArray.filter(
-    (v) => typeof v === "number",
-  ) as number[];
+  const multiSelectDefaultValue = normalizedIds;
 
   // For Select: value must be string or undefined
   const selectValue =
@@ -126,7 +125,6 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
           defaultValue={multiSelectDefaultValue}
           onChange={onChange}
           placeholder={placeholder}
-          className={disabled ? "opacity-60" : undefined}
         />
       ) : (
         <Select


### PR DESCRIPTION
## Summary
- normalize relation field value IDs properly
- adjust MultiSelect option mapping to match design-system types
- remove unsupported `className` prop

## Testing
- `node node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_684356cf0b908325bc029cfd336cff6a