### PR TITLE
Fix relation select display name

### DIFF
--- a/src/components/admin/StrapiRelationField.tsx
+++ b/src/components/admin/StrapiRelationField.tsx
@@ -67,15 +67,21 @@ export const StrapiRelationField: React.FC<StrapiRelationFieldProps> = ({
         if (!res.ok) throw new Error("Failed to fetch related data");
         const json = await res.json();
         const items = json.data || [];
-        const opts = items.map((item: any) => ({
-          label:
-            item.attributes?.[displayField] ||
-            item.attributes?.displayName ||
-            item.attributes?.name ||
-            item.id,
-          value: item.id,
-          link: `/admin/${collection}/${item.id}`,
-        }));
+        const opts = items.map((item: any) => {
+          const attrs = item.attributes || {};
+          return {
+            label:
+              attrs[displayField] ||
+              attrs.displayName ||
+              attrs.name ||
+              item[displayField] ||
+              item.displayName ||
+              item.name ||
+              item.id,
+            value: item.id,
+            link: `/admin/${collection}/${item.id}`,
+          };
+        });
         if (!ignore) setOptions(opts);
       } catch (e: any) {
         if (!ignore) setError(e.message || "Unknown error");

--- a/src/utils/relationHelpers.ts
+++ b/src/utils/relationHelpers.ts
@@ -13,7 +13,16 @@ export function extractLabels(
   if (value == null) return [];
   const getLabel = (v: any) => {
     if (typeof v === "object" && v !== null) {
-      return v[displayField] || v.displayName || v.name || String(v.id ?? "");
+      const attrs = (v as any).attributes || {};
+      return (
+        v[displayField] ||
+        v.displayName ||
+        v.name ||
+        attrs[displayField] ||
+        attrs.displayName ||
+        attrs.name ||
+        String(v.id ?? "")
+      );
     }
     return String(v);
   };


### PR DESCRIPTION
## Summary
- ensure Strapi relation options look for common name fields
- extract relation labels from attributes when present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435e2c0e8c832584f9172a2386b419