### PR TITLE
Fix admin form dirty state tracking

### DIFF
--- a/docs/tasks/completed/fix-record-dialog-dirty-state.md
+++ b/docs/tasks/completed/fix-record-dialog-dirty-state.md
@@ -1,0 +1,8 @@
+# Bugfix: Update button stuck disabled
+
+**Status:** Completed (2025-06-07)
+
+## Summary
+- Fixed regression where the update button inside `RecordFormDialog` remained disabled even after editing fields.
+- Dirty state is now emitted from `DynamicStrapiForm` via `onDirtyChange` and tracked in the dialog.
+- The dialog button re-enables when the form becomes dirty and warns if closing with unsaved changes.

--- a/src/components/admin/RecordFormDialog.tsx
+++ b/src/components/admin/RecordFormDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, Button, Label } from "@k2600x/design-system";
 import { useConfirm } from "@/hooks/useConfirm";
 import { DynamicStrapiForm } from "@/components/dynamic-form/DynamicStrapiForm";
@@ -34,7 +34,12 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
 }) => {
   // Create a ref to store the form submit function
   const formRef = useRef<{ submitForm: () => void; isDirty: () => boolean }>(null);
+  const [dirty, setDirty] = useState(false);
   const confirm = useConfirm();
+
+  useEffect(() => {
+    setDirty(false);
+  }, [record, open]);
 
   // Function to handle form submission from the footer button
   const handleFooterSubmit = () => {
@@ -45,7 +50,7 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
 
   const handleOpenChange = (val: boolean) => {
     if (!val) {
-      if (formRef.current?.isDirty()) {
+      if (dirty) {
         confirm({
           title: "¿Cerrar sin guardar?",
           description: "Hay cambios sin guardar.",
@@ -71,6 +76,7 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
             onError={() => {}}
             ref={formRef}
             hideSubmitButton={true} // Hide the form's own submit button
+            onDirtyChange={setDirty}
           />
         </div>
         <DialogFooter className="flex flex-col gap-2">
@@ -81,7 +87,7 @@ export const RecordFormDialog: React.FC<RecordFormDialogProps> = ({
           )}
           <Button
             onClick={handleFooterSubmit}
-            disabled={loading || !formRef.current?.isDirty()}
+            disabled={loading || !dirty}
           >
             {record ? "Update" : "Create"}
           </Button>

--- a/src/components/dynamic-form/DynamicStrapiForm.tsx
+++ b/src/components/dynamic-form/DynamicStrapiForm.tsx
@@ -15,6 +15,7 @@ export interface DynamicStrapiFormProps {
   onSuccess?: (values: any) => void;
   onError?: (err: any) => void;
   hideSubmitButton?: boolean; // Whether to hide the form's own submit button
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 export const DynamicStrapiForm = React.forwardRef<
@@ -27,7 +28,8 @@ export const DynamicStrapiForm = React.forwardRef<
     onSuccess,
     onError,
     hideSubmitButton = false,
-  }, 
+    onDirtyChange,
+  },
   ref
 ) => {
   // 1. Get schema from context
@@ -91,6 +93,10 @@ export const DynamicStrapiForm = React.forwardRef<
     },
     isDirty: () => formFactory.form.formState.isDirty,
   }));
+
+  React.useEffect(() => {
+    onDirtyChange?.(formFactory.form.formState.isDirty);
+  }, [formFactory.form.formState.isDirty, onDirtyChange]);
 
   // Render fields in a 3-column grid
   const renderFields = () => {


### PR DESCRIPTION
## Summary
- add `onDirtyChange` callback to `DynamicStrapiForm`
- track dirty state in `RecordFormDialog` and enable update button
- document the regression

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684837d4fd608325becc9a567493be74