### PR TITLE
Fix build type errors and font downloads

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,10 +5,6 @@ import { ConfirmDialog } from "@/components/ui";
 import { Toaster } from "sonner";
 import { ThemeScript } from "./ThemeScript";
 
-import { Inter, JetBrains_Mono } from "next/font/google";
-
-const inter = Inter({ subsets: ["latin"], variable: "--font-sans" });
-const mono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" });
 
 export const metadata: Metadata = {
   title: "Finance dashboard",
@@ -23,11 +19,7 @@ export default function RootLayout({
   // Note: We remove the ClientHeader from here
   // and will only use it in non-admin layouts
   return (
-    <html
-      lang="en"
-      className={`${inter.variable} ${mono.variable}`}
-      suppressHydrationWarning
-    >
+    <html lang="en" suppressHydrationWarning>
       <head />
       <body className="antialiased bg-background text-foreground" suppressHydrationWarning>
         <ThemeScript />

--- a/src/components/layout/AppShellLayout.tsx
+++ b/src/components/layout/AppShellLayout.tsx
@@ -27,9 +27,9 @@ export function AppShellLayout({
           cta={<ThemeToggle />}
           className="border-b border-border"
         />
-        <Container as="main" className="flex-1 py-[var(--spacing-md)]">
-          {children}
-        </Container>
+        <main className="flex-1 py-[var(--spacing-md)]">
+          <Container className="h-full">{children}</Container>
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fix container type error by removing unsupported `as` prop
- avoid Google font download during build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6855a44565888325a5c17f1526824cca