### PR TITLE
Add finance-dashboard module and admin route

### DIFF
--- a/src/app/(admin)/finance-dashboard/page.tsx
+++ b/src/app/(admin)/finance-dashboard/page.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { AppShellLayout } from '@/components/layout';
+
+export default function FinanceDashboardPage() {
+  const navbar = [
+    { label: 'Home', href: '/' },
+    { label: 'Finance Dashboard', href: '/finance-dashboard' },
+  ];
+  const sidebar = [
+    { label: 'Dashboard', href: '/finance-dashboard' },
+    { label: 'Admin', href: '/admin' },
+  ];
+
+  return (
+    <AppShellLayout navbarItems={navbar} sidebarItems={sidebar}>
+      <div className="max-w-7xl mx-auto py-8">
+        <h1 className="text-3xl font-bold mb-4">Finance Dashboard</h1>
+        <p>Welcome to the finance dashboard.</p>
+      </div>
+    </AppShellLayout>
+  );
+}

--- a/src/modules/finance-dashboard/__tests__/useFinanceData.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/useFinanceData.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useFinanceData } from '../hooks/useFinanceData';
+import strapi from '@/services/strapi';
+
+jest.mock('@/services/strapi');
+
+describe('useFinanceData', () => {
+  function TestComponent() {
+    const { data, loading } = useFinanceData();
+    if (loading) return <div>Loading</div>;
+    return <div>count:{data.length}</div>;
+  }
+
+  test('fetches data on mount and displays length', async () => {
+    (strapi.post as jest.Mock).mockResolvedValue({
+      data: [{ id: 1, name: 'A', amount: 10 }],
+    });
+
+    render(<TestComponent />);
+
+    expect(strapi.post).toHaveBeenCalledWith({ method: 'GET', collection: 'finance-data' });
+
+    await waitFor(() => {
+      expect(screen.getByText('count:1')).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/finance-dashboard/hooks/useFinanceData.ts
+++ b/src/modules/finance-dashboard/hooks/useFinanceData.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState, useCallback } from 'react';
+import { z } from 'zod';
+import strapi from '@/services/strapi';
+import { FinanceRecordSchema } from '../schemas/financeSchemas';
+
+export const FinanceRecordsSchema = z.array(FinanceRecordSchema);
+export type FinanceRecord = z.infer<typeof FinanceRecordSchema>;
+
+export function useFinanceData() {
+  const [data, setData] = useState<FinanceRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await strapi.post({ method: 'GET', collection: 'finance-data' });
+      const parsed = FinanceRecordsSchema.parse(res.data);
+      setData(parsed);
+    } catch (err: any) {
+      setError(err.message);
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refresh: fetchData };
+}

--- a/src/modules/finance-dashboard/routes/page.tsx
+++ b/src/modules/finance-dashboard/routes/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+import React from 'react';
+import { AppShellLayout } from '@/components/layout';
+
+export default function FinanceDashboardModulePage() {
+  const navbar = [{ label: 'Home', href: '/' }, { label: 'Finance Dashboard', href: '/finance-dashboard' }];
+  const sidebar = [{ label: 'Finance Dashboard', href: '/finance-dashboard' }];
+  return (
+    <AppShellLayout navbarItems={navbar} sidebarItems={sidebar}>
+      <div>Finance Dashboard Module page</div>
+    </AppShellLayout>
+  );
+}

--- a/src/modules/finance-dashboard/schemas/financeSchemas.ts
+++ b/src/modules/finance-dashboard/schemas/financeSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const FinanceRecordSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  amount: z.number(),
+});
+
+export type FinanceRecord = z.infer<typeof FinanceRecordSchema>;

--- a/src/modules/finance-dashboard/types/index.ts
+++ b/src/modules/finance-dashboard/types/index.ts
@@ -1,0 +1,1 @@
+export type { FinanceRecord } from '../schemas/financeSchemas';


### PR DESCRIPTION
## Summary
- scaffold `finance-dashboard` module
- add example hook with zod validation and accompanying test
- add route `app/(admin)/finance-dashboard` rendering `AppShellLayout`
- create placeholder module route page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68569e5f31b08325bc184a314abda642