### PR TITLE
Add DynamicForm component with zod validation

### DIFF
--- a/src/modules/finance-dashboard/__tests__/DynamicForm.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/DynamicForm.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import { DynamicForm, DynamicField } from '../components/DynamicForm';
+import { z } from 'zod';
+
+jest.mock('@k2600x/design-system', () => {
+  const React = require('react');
+  return {
+    Input: React.forwardRef((props: any, ref) => <input ref={ref} {...props} />),
+    Button: (props: any) => <button {...props}>{props.children}</button>,
+    Select: (props: any) => <select {...props}>{props.children}</select>,
+    SelectTrigger: (props: any) => <div {...props}>{props.children}</div>,
+    SelectContent: (props: any) => <div {...props}>{props.children}</div>,
+    SelectItem: (props: any) => <option value={props.value}>{props.children}</option>,
+    Label: (props: any) => <label {...props}>{props.children}</label>,
+  };
+});
+
+describe('DynamicForm', () => {
+  const fields: DynamicField[] = [
+    { name: 'name', label: 'Name', type: 'text', placeholder: 'Name' },
+    { name: 'age', label: 'Age', type: 'number', placeholder: 'Age' },
+  ];
+  const schema = z.object({
+    name: z.string().min(1),
+    age: z.coerce.number().min(0),
+  });
+
+  test('submits valid data', async () => {
+    const onSubmit = jest.fn();
+    const { getByLabelText, getByRole } = render(
+      <DynamicForm schema={schema} fields={fields} defaultValues={{}} onSubmit={onSubmit} />
+    );
+
+    fireEvent.change(getByLabelText('Name'), { target: { value: 'John' } });
+    fireEvent.change(getByLabelText('Age'), { target: { value: '30' } });
+
+    fireEvent.click(getByRole('button'));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledWith({ name: 'John', age: 30 }));
+  });
+
+  test('shows validation error', async () => {
+    const { getByRole, findByText } = render(
+      <DynamicForm schema={schema} fields={fields} defaultValues={{}} onSubmit={jest.fn()} />
+    );
+
+    fireEvent.click(getByRole('button'));
+
+    expect(await findByText(/name/i)).toBeTruthy();
+  });
+});

--- a/src/modules/finance-dashboard/components/DynamicForm.tsx
+++ b/src/modules/finance-dashboard/components/DynamicForm.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z, ZodSchema } from "zod";
+import {
+  Input,
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  Button,
+  Label,
+} from "@k2600x/design-system";
+
+export type DynamicField = {
+  name: string;
+  label: string;
+  type: "text" | "number" | "select" | "checkbox" | "date";
+  placeholder?: string;
+  options?: { label: string; value: string | number }[];
+};
+
+export interface DynamicFormProps<T extends Record<string, any>> {
+  schema: ZodSchema<T>;
+  fields: DynamicField[];
+  defaultValues: Partial<T>;
+  onSubmit: (values: T) => Promise<void> | void;
+}
+
+export function DynamicForm<T extends Record<string, any>>({
+  schema,
+  fields,
+  defaultValues,
+  onSubmit,
+}: DynamicFormProps<T>) {
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isSubmitSuccessful },
+  } = useForm<T>({
+    resolver: zodResolver(schema),
+    defaultValues: defaultValues as any,
+  });
+
+  const [success, setSuccess] = React.useState(false);
+
+  const submitHandler = async (values: T) => {
+    await onSubmit(values);
+    setSuccess(true);
+    setTimeout(() => setSuccess(false), 2000);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submitHandler)} className="flex flex-col gap-4">
+      {fields.map((field) => {
+        const errorMsg = (errors as any)[field.name]?.message as string | undefined;
+        const commonProps = {
+          id: field.name,
+          placeholder: field.placeholder,
+          ...register(field.name as any),
+        };
+
+        return (
+          <div key={field.name} className="flex flex-col gap-1">
+            <Label htmlFor={field.name}>{field.label}</Label>
+            {field.type === "select" ? (
+              <Controller
+                control={control}
+                name={field.name as any}
+                render={({ field: ctrl }) => (
+                  <Select
+                    value={ctrl.value}
+                    onValueChange={(val) => ctrl.onChange(val)}
+                  >
+                    <SelectTrigger>{ctrl.value || field.placeholder}</SelectTrigger>
+                    <SelectContent>
+                      {field.options?.map((opt) => (
+                        <SelectItem key={opt.value} value={String(opt.value)}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            ) : field.type === "checkbox" ? (
+              <Controller
+                control={control}
+                name={field.name as any}
+                render={({ field: ctrl }) => (
+                  <input
+                    type="checkbox"
+                    checked={!!ctrl.value}
+                    onChange={(e) => ctrl.onChange(e.target.checked)}
+                  />
+                )}
+              />
+            ) : (
+              <Input type={field.type} {...commonProps} />
+            )}
+            {errorMsg && <span className="text-destructive text-sm">{errorMsg}</span>}
+          </div>
+        );
+      })}
+      {isSubmitSuccessful && success && (
+        <p className="text-success">Guardado correctamente</p>
+      )}
+      <Button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? "Enviando..." : "Enviar"}
+      </Button>
+    </form>
+  );
+}
+
+export default DynamicForm;


### PR DESCRIPTION
## Summary
- add `DynamicForm` component to finance-dashboard
- create unit tests for the dynamic form

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6856dfc3227883258ab2ce2e98d17b31