### PR TITLE
Add useStrapiCollection hook

### DIFF
--- a/src/modules/finance-dashboard/hooks/useStrapiCollection.ts
+++ b/src/modules/finance-dashboard/hooks/useStrapiCollection.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from 'react';
+import { z } from 'zod';
+import strapi from '@/services/strapi';
+import type { StrapiResponse, StrapiPaginationMeta } from '@/types/strapi';
+
+export interface TableColumn {
+  accessorKey: string;
+  header: string;
+  cell: (row: any) => any;
+}
+
+export function useStrapiCollection(modelName: string) {
+  const [data, setData] = useState<any[]>([]);
+  const [columns, setColumns] = useState<TableColumn[]>([]);
+  const [pagination, setPagination] = useState<StrapiPaginationMeta['pagination']>({
+    page: 1,
+    pageSize: 10,
+    pageCount: 0,
+    total: 0,
+  });
+
+  const fetchSchema = useCallback(async () => {
+    try {
+      const res = await strapi.post({ method: 'SCHEMA', schemaUid: modelName });
+      const schema = Array.isArray(res.data) ? res.data[0] : res.data;
+      const attributes = schema?.schema?.attributes || {};
+      const cols: TableColumn[] = Object.keys(attributes).map((name) => ({
+        accessorKey: name,
+        header: name,
+        cell: (row: any) => row[name],
+      }));
+      setColumns(cols);
+    } catch {
+      setColumns([]);
+    }
+  }, [modelName]);
+
+  const fetchData = useCallback(
+    async (page: number = pagination.page, pageSize: number = pagination.pageSize) => {
+      try {
+        const res: StrapiResponse<any> = await strapi.post({
+          method: 'GET',
+          collection: modelName,
+          query: { populate: '*', pagination: { page, pageSize } },
+        });
+        const parsed = z.array(z.record(z.any())).parse(res.data);
+        setData(parsed);
+        if (res.meta?.pagination) {
+          setPagination(res.meta.pagination);
+        }
+      } catch {
+        setData([]);
+      }
+    },
+    [modelName, pagination.page, pagination.pageSize],
+  );
+
+  const refetch = useCallback(() => {
+    fetchData(pagination.page, pagination.pageSize);
+  }, [fetchData, pagination.page, pagination.pageSize]);
+
+  useEffect(() => {
+    fetchSchema();
+  }, [fetchSchema]);
+
+  useEffect(() => {
+    fetchData(1, pagination.pageSize);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fetchData, modelName]);
+
+  return { data, columns, pagination, refetch };
+}

--- a/src/modules/finance-dashboard/useStrapiCollection.vitest.ts
+++ b/src/modules/finance-dashboard/useStrapiCollection.vitest.ts
@@ -1,0 +1,41 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { useStrapiCollection } from './hooks/useStrapiCollection';
+import strapi from '@/services/strapi';
+
+vi.mock('@/services/strapi');
+
+const mockSchema = {
+  data: [
+    {
+      uid: 'api::record.record',
+      schema: {
+        attributes: {
+          title: { type: 'string' },
+          amount: { type: 'integer' },
+        },
+      },
+    },
+  ],
+};
+
+const mockData = {
+  data: [{ id: 1, title: 'A', amount: 10 }],
+  meta: { pagination: { page: 1, pageSize: 10, pageCount: 1, total: 1 } },
+};
+
+describe('useStrapiCollection', () => {
+  it('fetches schema and data, generating columns', async () => {
+    (strapi.post as any).mockResolvedValueOnce(mockSchema);
+    (strapi.post as any).mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useStrapiCollection('api::record.record'));
+
+    await waitFor(() => result.current.columns.length > 0);
+    await waitFor(() => result.current.data.length > 0);
+
+    expect(result.current.data).toEqual(mockData.data);
+    expect(result.current.columns.map((c) => c.accessorKey)).toEqual(['title', 'amount']);
+    expect(result.current.pagination.total).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- implement `useStrapiCollection` for finance dashboard
- generate table columns from Strapi model schema
- add vitest covering data and column shapes

## Testing
- `npm test`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6856dfd493f08325a8129bae0335fd0c