### PR TITLE
Add finance dashboard v2 route and schema hook test

### DIFF
--- a/src/app/admin/finance-dashboard/page.tsx
+++ b/src/app/admin/finance-dashboard/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import React, { useState } from "react";
+import Link from "next/link";
+import { AppShellLayout } from "@/components/layout";
+import { DynamicForm } from "@/modules/finance-dashboard/components/DynamicForm";
+import { SmartDataTable } from "@/modules/finance-dashboard/components/SmartDataTable";
+import { useStrapiCollection } from "@/modules/finance-dashboard/hooks/useStrapiCollection";
+import { useStrapiForm } from "@/modules/finance-dashboard/hooks/useStrapiForm";
+import useStrapiSchema from "@/hooks/useStrapiSchema";
+
+export default function AdminFinanceDashboardPage() {
+  const { schemas } = useStrapiSchema();
+  const [model, setModel] = useState<string>(schemas[0]?.uid || "");
+
+  const { data, columns, pagination, refetch } = useStrapiCollection(model);
+  const { schema, defaultValues, fields, onSubmit } = useStrapiForm(model, "update");
+
+  const handlePageChange = () => {
+    refetch();
+  };
+
+  return (
+    <AppShellLayout title="Admin v2: Dynamic Collections" navbarItems={[]} sidebarItems={[]}> 
+      <div className="p-4 space-y-6">
+        <div className="flex space-x-4 mb-4">
+          <Link href="/admin" className="underline hover:text-primary">
+            Go to Admin v1
+          </Link>
+          <Link href="/admin/finance-dashboard" className="underline font-semibold hover:text-primary">
+            Admin v2 (Current)
+          </Link>
+        </div>
+
+        <section>
+          <label htmlFor="collection-select" className="block mb-2 font-medium text-sm">Select Collection</label>
+          <select
+            id="collection-select"
+            className="p-2 border rounded"
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+          >
+            {schemas.map((s) => (
+              <option key={s.uid} value={s.uid}>
+                {s.info.displayName}
+              </option>
+            ))}
+          </select>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold">List of {model}</h2>
+          <SmartDataTable
+            data={data}
+            columns={columns}
+            pagination={{
+              totalItems: pagination.total,
+              itemsPerPage: pagination.pageSize,
+              currentPage: pagination.page,
+            }}
+            onEdit={(row) => {
+              onSubmit(row);
+              refetch();
+            }}
+            onPageChange={handlePageChange}
+            collection={model}
+          />
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold">Edit or Create {model}</h2>
+          <DynamicForm
+            schema={schema}
+            fields={fields}
+            defaultValues={defaultValues}
+            onSubmit={async (values) => {
+              await onSubmit(values);
+              refetch();
+            }}
+          />
+        </section>
+      </div>
+    </AppShellLayout>
+  );
+}
+

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
+import Link from "next/link";
 import { useStrapiSchemas } from "@/context/StrapiSchemaProvider";
 import strapi from "@/lib/strapi";
 import { Button, Tooltip } from "@k2600x/design-system";
@@ -141,6 +142,11 @@ export default function AdminPage() {
         />
       }
     >
+      <div className="mb-2 text-right">
+        <Link href="/admin/finance-dashboard" className="underline text-sm hover:text-primary">
+          Go to Admin v2
+        </Link>
+      </div>
       <div className="flex justify-between items-center mb-6 w-full">
         <h1 className="text-2xl font-bold text-left">
           {selectedCollection ? getSchemaDisplayName(schemas[selectedCollection], selectedCollection) : "Select a Collection"}

--- a/src/hooks/useStrapiSchema.test.ts
+++ b/src/hooks/useStrapiSchema.test.ts
@@ -1,0 +1,33 @@
+import useStrapiSchema from './useStrapiSchema';
+
+let capturedQueryFn: any;
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (config: any) => {
+    capturedQueryFn = config.queryFn;
+    return { data: undefined, error: undefined, isLoading: false };
+  },
+}));
+
+jest.mock('@/services/strapi', () => ({
+  post: jest.fn(() => Promise.resolve({ data: {} })),
+}));
+import strapi from '@/services/strapi';
+
+afterEach(() => {
+  (strapi.post as jest.Mock).mockClear();
+});
+
+test('fetches all schemas when no UID provided', async () => {
+  useStrapiSchema();
+  await capturedQueryFn();
+  expect(strapi.post).toHaveBeenCalledWith({ method: 'SCHEMA' });
+});
+
+test('passes schemaUid when provided', async () => {
+  useStrapiSchema('api::post.post');
+  await capturedQueryFn();
+  expect(strapi.post).toHaveBeenCalledWith({
+    method: 'SCHEMA',
+    schemaUid: 'api::post.post',
+  });
+});


### PR DESCRIPTION
## Summary
- link Admin v1 to Admin v2
- implement `/admin/finance-dashboard` route using dynamic components
- add unit tests for `useStrapiSchema`

## Testing
- `node node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_6856fa1830a88325aaed4f02618dfa95