### PR TITLE
Add NextAuth session handling to finance dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "formidable": "^3.5.2",
         "lucide-react": "^0.477.0",
         "next": "^14.2.3",
+        "next-auth": "^4.24.11",
         "react": "^18.2.0",
         "react-datepicker": "^8.1.0",
         "react-dom": "^18.2.0",
@@ -3529,6 +3530,15 @@
       "dev": true,
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -7097,6 +7107,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.42.0",
@@ -11032,6 +11051,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -11880,6 +11908,38 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/next/node_modules/@swc/helpers": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
@@ -12005,12 +12065,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -12136,6 +12211,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
+      "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -12157,6 +12241,39 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -12441,6 +12558,34 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/preact": {
+      "version": "10.26.9",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
+      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/preact-render-to-string/node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -14481,6 +14626,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "formidable": "^3.5.2",
     "lucide-react": "^0.477.0",
     "next": "^14.2.3",
+    "next-auth": "^4.24.11",
     "react": "^18.2.0",
     "react-datepicker": "^8.1.0",
     "react-dom": "^18.2.0",

--- a/src/modules/finance-dashboard/routes/page.tsx
+++ b/src/modules/finance-dashboard/routes/page.tsx
@@ -1,13 +1,122 @@
 'use client';
-import React from 'react';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { useSession, signIn } from 'next-auth/react';
+import { ThemeProvider } from '@k2600x/design-system';
 import { AppShellLayout } from '@/components/layout';
+import { DynamicForm } from '../components/DynamicForm';
+import { SmartDataTable } from '../components/SmartDataTable';
+import { useStrapiCollection } from '../hooks/useStrapiCollection';
+import { useStrapiForm } from '../hooks/useStrapiForm';
+import useStrapiSchema from '@/hooks/useStrapiSchema';
 
 export default function FinanceDashboardModulePage() {
-  const navbar = [{ label: 'Home', href: '/' }, { label: 'Finance Dashboard', href: '/finance-dashboard' }];
-  const sidebar = [{ label: 'Finance Dashboard', href: '/finance-dashboard' }];
+  // Manejo de sesión similar a Admin v1
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return <div>Cargando sesión...</div>;
+  }
+
+  if (status === 'unauthenticated') {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <p className="mb-4">Debes iniciar sesión para acceder al admin.</p>
+        <button
+          onClick={() => signIn()}
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          Iniciar sesión
+        </button>
+      </div>
+    );
+  }
+
+  const { data: schemaData } = useStrapiSchema();
+  const schemas = Array.isArray(schemaData?.data) ? schemaData.data : [];
+  const [model, setModel] = useState<string>('');
+
+  useEffect(() => {
+    if (!model && schemas.length > 0) {
+      setModel(schemas[0].uid);
+    }
+  }, [model, schemas]);
+
+  const { data, columns, pagination, refetch } = useStrapiCollection(model);
+  const { schema, defaultValues, fields, onSubmit } = useStrapiForm(model, 'update');
+
+  const handlePageChange = () => {
+    refetch();
+  };
+
   return (
-    <AppShellLayout navbarItems={navbar} sidebarItems={sidebar}>
-      <div>Finance Dashboard Module page</div>
-    </AppShellLayout>
+    <ThemeProvider initialTheme="futuristic">
+      <AppShellLayout navbarItems={[]} sidebarItems={[]}>
+        <div className="p-4 space-y-6">
+          <div className="flex space-x-4 mb-4">
+            <Link href="/admin" className="underline hover:text-primary">
+              Ir a Admin v1
+            </Link>
+            <Link
+              href="/admin/finance-dashboard"
+              className="underline font-semibold hover:text-primary"
+            >
+              Admin v2 (Actual)
+            </Link>
+          </div>
+
+          <section>
+            <label htmlFor="collection-select" className="block mb-2 font-medium text-sm">
+              Colección
+            </label>
+            <select
+              id="collection-select"
+              className="p-2 border rounded"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              {schemas.map((s: any) => (
+                <option key={s.uid} value={s.uid}>
+                  {s.info.displayName}
+                </option>
+              ))}
+            </select>
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold">Listado de {model}</h2>
+            <SmartDataTable
+              data={data}
+              columns={columns}
+              pagination={{
+                totalItems: pagination.total,
+                itemsPerPage: pagination.pageSize,
+                currentPage: pagination.page,
+              }}
+              onEdit={(row) => {
+                onSubmit(row);
+                refetch();
+              }}
+              onPageChange={handlePageChange}
+              collection={model}
+            />
+          </section>
+
+          <section>
+            <h2 className="text-lg font-semibold">Editar / Crear {model}</h2>
+            <DynamicForm
+              schema={schema as any}
+              fields={fields as any}
+              defaultValues={defaultValues}
+              onSubmit={async (values) => {
+                await onSubmit(values);
+                refetch();
+              }}
+            />
+          </section>
+        </div>
+      </AppShellLayout>
+    </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- add `next-auth` dependency
- secure the finance dashboard route with session handling

## Testing
- `npm test --silent`
- `npx vitest run --silent`


------
https://chatgpt.com/codex/tasks/task_e_685704219fc083258be668046b4b3d6d