### PR TITLE
Add account API integration and client rendering

### DIFF
--- a/src/modules/finance-dashboard/__tests__/AccountList.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/AccountList.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import "@testing-library/jest-dom";
+import { render, screen } from '@testing-library/react';
+import { AccountList } from '../components/AccountList';
+import { useAccounts } from '../hooks/useAccounts';
+
+jest.mock('../hooks/useAccounts');
+
+jest.mock('@k2600x/design-system', () => {
+  const React = require('react');
+  return {
+    Table: ({ data, columns }: any) => (
+      <table>
+        <tbody>
+          {data.map((row: any) => (
+            <tr key={row.id}>
+              {columns.map((c: any) => (
+                <td key={c.accessorKey}>{row[c.accessorKey]}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    ),
+  };
+});
+
+describe('AccountList', () => {
+  test('renders accounts from hook', () => {
+    (useAccounts as jest.Mock).mockReturnValue({
+      data: [{ id: 1, name: 'Test', balance: 20 }],
+      loading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    render(<AccountList />);
+
+    expect(screen.getByText('Test')).toBeInTheDocument();
+  });
+});

--- a/src/modules/finance-dashboard/__tests__/useAccounts.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/useAccounts.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useAccounts } from '../hooks/useAccounts';
+import { fetchAccounts } from '@/services/accountService';
+
+jest.mock('@/services/accountService');
+
+describe('useAccounts', () => {
+  function TestComponent() {
+    const { data, loading } = useAccounts();
+    if (loading) return <div>Loading</div>;
+    return <div>count:{data.length}</div>;
+  }
+
+  test('fetches account data and displays length', async () => {
+    (fetchAccounts as jest.Mock).mockResolvedValue([
+      { id: 1, name: 'A', balance: 10 },
+    ]);
+
+    render(<TestComponent />);
+
+    expect(fetchAccounts).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByText('count:1')).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/finance-dashboard/components/AccountList.tsx
+++ b/src/modules/finance-dashboard/components/AccountList.tsx
@@ -1,0 +1,27 @@
+"use client";
+import React from 'react';
+import { Table } from '@k2600x/design-system';
+import type { ColumnDef } from '@tanstack/react-table';
+import { useAccounts } from '../hooks/useAccounts';
+import type { Account } from '../schemas/accountSchemas';
+
+export function AccountList() {
+  const { data, loading, error } = useAccounts();
+
+  const columns: ColumnDef<Account>[] = [
+    { accessorKey: 'id', header: 'ID' },
+    { accessorKey: 'name', header: 'Name' },
+    {
+      accessorKey: 'balance',
+      header: 'Balance',
+      cell: ({ row }) => Number(row.original.balance).toFixed(2),
+    },
+  ];
+
+  if (loading) return <div className="p-6 text-center">Loading...</div>;
+  if (error) return <div className="p-6 text-center text-destructive">{error}</div>;
+
+  return <Table data={data} columns={columns as any} />;
+}
+
+export default AccountList;

--- a/src/modules/finance-dashboard/hooks/useAccounts.ts
+++ b/src/modules/finance-dashboard/hooks/useAccounts.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState, useCallback } from 'react';
+import { fetchAccounts, Account } from '@/services/accountService';
+
+export function useAccounts() {
+  const [data, setData] = useState<Account[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const accounts = await fetchAccounts();
+      setData(accounts);
+    } catch (err: any) {
+      setError(err.message);
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, refresh: load };
+}

--- a/src/modules/finance-dashboard/schemas/accountSchemas.ts
+++ b/src/modules/finance-dashboard/schemas/accountSchemas.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const AccountSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  balance: z.number(),
+});
+
+export type Account = z.infer<typeof AccountSchema>;

--- a/src/modules/finance-dashboard/types/index.ts
+++ b/src/modules/finance-dashboard/types/index.ts
@@ -1,1 +1,2 @@
 export type { FinanceRecord } from '../schemas/financeSchemas';
+export type { Account } from '../schemas/accountSchemas';

--- a/src/services/accountService.test.ts
+++ b/src/services/accountService.test.ts
@@ -1,0 +1,12 @@
+import { fetchAccounts } from './accountService';
+import strapi from './strapi';
+
+jest.mock('./strapi');
+
+describe('fetchAccounts', () => {
+  test('requests accounts collection', async () => {
+    (strapi.post as jest.Mock).mockResolvedValue({ data: [] });
+    await fetchAccounts();
+    expect(strapi.post).toHaveBeenCalledWith({ method: 'GET', collection: 'accounts' });
+  });
+});

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+import strapi from './strapi';
+import { AccountSchema } from '@/modules/finance-dashboard/schemas/accountSchemas';
+
+const AccountsSchema = z.array(AccountSchema);
+
+export type Account = z.infer<typeof AccountSchema>;
+
+export async function fetchAccounts(): Promise<Account[]> {
+  const res = await strapi.post({ method: 'GET', collection: 'accounts' });
+  return AccountsSchema.parse(res.data);
+}


### PR DESCRIPTION
## Summary
- add zod schema for accounts
- create accountService to fetch account data via Strapi
- implement `useAccounts` hook using the new service
- add `AccountList` component to display account data
- expose Account type
- unit tests for service, hook, and component

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685704219fc083258be668046b4b3d6d