### PR TITLE
Implement futuristic theme

### DIFF
--- a/src/app/ThemeScript.tsx
+++ b/src/app/ThemeScript.tsx
@@ -1,6 +1,6 @@
 // ThemeScript.tsx
-// This script injects the correct theme class (dark/light) before React hydration to prevent flashing.
-// It uses localStorage preference, falls back to system, and updates on system changes.
+// This script injects the correct theme class before React hydration to prevent flashing.
+// It now supports the "futuristic" theme from the design system.
 
 'use client';
 
@@ -9,18 +9,18 @@ import { useEffect } from 'react';
 export function ThemeScript() {
   useEffect(() => {
     // Helper to set theme class
-    function setThemeClass(theme: 'dark' | 'light') {
-      document.documentElement.classList.remove('dark', 'light');
+    function setThemeClass(theme: 'dark' | 'light' | 'futuristic') {
+      document.documentElement.classList.remove('dark', 'light', 'futuristic');
       document.documentElement.classList.add(theme);
     }
 
     // Check localStorage
     let theme = typeof window !== 'undefined' && window.localStorage.getItem('theme');
-    if (theme !== 'dark' && theme !== 'light') {
-      // Fallback to system
-      theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    if (theme !== 'dark' && theme !== 'light' && theme !== 'futuristic') {
+      theme = 'futuristic';
+      window.localStorage.setItem('theme', theme);
     }
-    setThemeClass(theme as 'dark' | 'light');
+    setThemeClass(theme as 'dark' | 'light' | 'futuristic');
 
     // Listen for system changes
     const mq = window.matchMedia('(prefers-color-scheme: dark)');

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -6,12 +6,17 @@ export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
 
   const handleToggle = () => {
-    setTheme(theme === "dark" ? "light" : "dark");
+    const nextTheme = theme === "light" ? "dark" : theme === "dark" ? "futuristic" : "light";
+    setTheme(nextTheme);
   };
 
   return (
     <Button variant="ghost" size="sm" onClick={handleToggle} aria-label="Toggle theme">
-      <Icon name={theme === "dark" ? "Sun" : "Moon"} size="sm" aria-hidden />
+      <Icon
+        name={theme === "light" ? "Moon" : theme === "dark" ? "Star" : "Sun"}
+        size="sm"
+        aria-hidden
+      />
     </Button>
   );
 }

--- a/src/components/layout/__tests__/ThemeToggle.test.tsx
+++ b/src/components/layout/__tests__/ThemeToggle.test.tsx
@@ -13,13 +13,13 @@ jest.mock('@k2600x/design-system', () => ({
 }));
 
 describe('ThemeToggle', () => {
-  test('toggles from dark to light', () => {
+  test('cycles from dark to futuristic', () => {
     const setTheme = jest.fn();
     (useTheme as jest.Mock).mockReturnValue({ theme: 'dark', setTheme });
 
     const { getByRole } = render(<ThemeToggle />);
     fireEvent.click(getByRole('button'));
 
-    expect(setTheme).toHaveBeenCalledWith('light');
+    expect(setTheme).toHaveBeenCalledWith('futuristic');
   });
 });


### PR DESCRIPTION
## Summary
- add futuristic theme option in ThemeToggle
- default app theme to futuristic via ThemeScript
- update theme toggle tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ca2c816c8325ab9d53a60bdb2841