### PR TITLE
Implement dynamic finance admin hooks

### DIFF
--- a/src/modules/finance-dashboard/__tests__/useStrapiSchema.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/useStrapiSchema.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useStrapiSchema } from '../hooks/useStrapiSchema';
+import { strapiService } from '@/services/strapiService';
+
+jest.mock('@/services/strapiService');
+
+describe('useStrapiSchema', () => {
+  function TestComponent() {
+    const { schemas, loading } = useStrapiSchema();
+    if (loading) return <div>Loading</div>;
+    return <div>count:{schemas.length}</div>;
+  }
+
+  test('fetches schemas on mount', async () => {
+    (strapiService.getCollection as jest.Mock).mockResolvedValue({
+      data: { data: [{ uid: 'a', info: { displayName: 'A' }, attributes: {} }] },
+    });
+
+    render(<TestComponent />);
+
+    expect(strapiService.getCollection).toHaveBeenCalledWith(
+      'content-type-builder/content-types'
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('count:1')).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/finance-dashboard/__tests__/useUser.test.tsx
+++ b/src/modules/finance-dashboard/__tests__/useUser.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useUser } from '../hooks/useUser';
+import { strapiService } from '@/services/strapiService';
+
+jest.mock('@/services/strapiService');
+
+describe('useUser', () => {
+  function TestComponent() {
+    const { user, loading } = useUser();
+    if (loading) return <div>Loading</div>;
+    return <div>{user?.username}</div>;
+  }
+
+  test('fetches current user and renders username', async () => {
+    (strapiService.getCollection as jest.Mock).mockResolvedValue({
+      user: { id: 1, username: 'tester', email: 't@test.com' },
+    });
+
+    render(<TestComponent />);
+
+    expect(strapiService.getCollection).toHaveBeenCalledWith('me');
+
+    await waitFor(() => {
+      expect(screen.getByText('tester')).toBeTruthy();
+    });
+  });
+});

--- a/src/modules/finance-dashboard/hooks/useStrapiSchema.ts
+++ b/src/modules/finance-dashboard/hooks/useStrapiSchema.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+import { strapiService } from '@/services/strapiService';
+import { z } from 'zod';
+
+export const StrapiSchemaItemSchema = z.object({
+  uid: z.string(),
+  info: z.object({ displayName: z.string() }),
+  attributes: z.record(z.any()),
+});
+
+export type StrapiSchema = z.infer<typeof StrapiSchemaItemSchema>;
+
+export function useStrapiSchema() {
+  const [schemas, setSchemas] = useState<StrapiSchema[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await strapiService.getCollection('content-type-builder/content-types');
+        const items = (res as any).data?.data ?? (res as any).data ?? res;
+        const parsed = z.array(StrapiSchemaItemSchema).parse(items);
+        setSchemas(parsed);
+      } catch (e: any) {
+        setError(e.message);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  return { schemas, loading, error };
+}

--- a/src/modules/finance-dashboard/hooks/useUser.ts
+++ b/src/modules/finance-dashboard/hooks/useUser.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from 'react';
+import { strapiService } from '@/services/strapiService';
+import { z } from 'zod';
+
+export const UserSchema = z.object({
+  id: z.number(),
+  username: z.string(),
+  email: z.string(),
+}).passthrough();
+
+export type User = z.infer<typeof UserSchema>;
+
+const ResponseSchema = z.object({ user: UserSchema.optional() });
+
+export function useUser() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    strapiService
+      .getCollection('me')
+      .then((res) => {
+        const parsed = ResponseSchema.parse(res);
+        setUser(parsed.user ?? null);
+      })
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { user, loading };
+}

--- a/src/modules/finance-dashboard/routes/page.tsx
+++ b/src/modules/finance-dashboard/routes/page.tsx
@@ -1,13 +1,91 @@
 'use client';
-import React from 'react';
-import { AppShellLayout } from '@/components/layout';
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { ThemeProvider, AppShellLayout } from '@k2600x/design-system';
+import { useUser } from '../hooks/useUser';
+import { useStrapiSchema } from '../hooks/useStrapiSchema';
+import { useStrapiCollection } from '../hooks/useStrapiCollection';
+import { useStrapiForm } from '../hooks/useStrapiForm';
+import { SmartDataTable } from '../components/SmartDataTable';
+import { DynamicForm } from '../components/DynamicForm';
 
-export default function FinanceDashboardModulePage() {
-  const navbar = [{ label: 'Home', href: '/' }, { label: 'Finance Dashboard', href: '/finance-dashboard' }];
-  const sidebar = [{ label: 'Finance Dashboard', href: '/finance-dashboard' }];
+export default function FinanceDashboardPage() {
+  const { user, loading: userLoading } = useUser();
+  if (userLoading) return <div>Cargando sesión...</div>;
+  if (!user) {
+    return (
+      <div className="flex flex-col items-center justify-center h-full">
+        <p className="mb-4">Debes iniciar sesión para acceder al admin.</p>
+        <button
+          onClick={() => (window.location.href = '/admin')}
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          Ir a Login
+        </button>
+      </div>
+    );
+  }
+
+  const { schemas, loading: schemasLoading, error: schemasError } = useStrapiSchema();
+  const [model, setModel] = useState<string>('');
+  if (schemasLoading) return <div>Cargando esquemas...</div>;
+  if (schemasError || schemas.length === 0) return <div>Error al cargar esquemas</div>;
+  if (!model) setModel(schemas[0].uid);
+
+  const { data, columns, pagination, refetch } = useStrapiCollection(model);
+  const { schema, defaultValues, fields, onSubmit } = useStrapiForm(model, 'update');
+
   return (
-    <AppShellLayout navbarItems={navbar} sidebarItems={sidebar}>
-      <div>Finance Dashboard Module page</div>
-    </AppShellLayout>
+    <ThemeProvider initialTheme="futuristic">
+      <AppShellLayout title="Admin v2: Dynamic Collections" theme="futuristic">
+        <div className="p-4 space-y-6">
+          <div className="flex space-x-4 mb-4">
+            <Link href="/admin" className="underline">Admin v1</Link>
+            <Link href="/admin/finance-dashboard" className="underline font-semibold">Admin v2</Link>
+          </div>
+          <section>
+            <label htmlFor="collection-select" className="block mb-2 font-medium text-sm">Colección</label>
+            <select
+              id="collection-select"
+              className="p-2 border rounded"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              {schemas.map((s) => (
+                <option key={s.uid} value={s.uid}>
+                  {s.info.displayName}
+                </option>
+              ))}
+            </select>
+          </section>
+          <section>
+            <h2 className="text-lg font-semibold">Listado de {model}</h2>
+            <SmartDataTable
+              data={data}
+              columns={columns}
+              pagination={pagination}
+              onPageChange={() => {}}
+              onEdit={(row) => {
+                onSubmit(row);
+                refetch();
+              }}
+              collection={model}
+            />
+          </section>
+          <section>
+            <h2 className="text-lg font-semibold">Editar / Crear {model}</h2>
+            <DynamicForm
+              schema={schema}
+              fields={fields}
+              defaultValues={defaultValues}
+              onSubmit={async (values) => {
+                await onSubmit(values);
+                refetch();
+              }}
+            />
+          </section>
+        </div>
+      </AppShellLayout>
+    </ThemeProvider>
   );
 }

--- a/src/modules/finance-dashboard/types/form.ts
+++ b/src/modules/finance-dashboard/types/form.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import type { DynamicField } from '../components/DynamicForm';
+
+export interface FormConfig<T extends Record<string, any>> {
+  schema: z.ZodType<T>;
+  fields: DynamicField[];
+  defaultValues: Partial<T>;
+}

--- a/src/modules/finance-dashboard/types/index.ts
+++ b/src/modules/finance-dashboard/types/index.ts
@@ -1,2 +1,4 @@
 export type { FinanceRecord } from '../schemas/financeSchemas';
 export type { Account } from '../schemas/accountSchemas';
+export type { FormConfig } from './form';
+export type { PaginationState, TableProps } from './table';

--- a/src/modules/finance-dashboard/types/table.ts
+++ b/src/modules/finance-dashboard/types/table.ts
@@ -1,0 +1,13 @@
+import type { ColumnDef } from '@tanstack/react-table';
+
+export interface PaginationState {
+  totalItems: number;
+  itemsPerPage: number;
+  currentPage: number;
+}
+
+export interface TableProps<T> {
+  data: T[];
+  columns: ColumnDef<T, any>[];
+  pagination: PaginationState;
+}

--- a/src/services/strapiService.test.ts
+++ b/src/services/strapiService.test.ts
@@ -1,0 +1,14 @@
+import { strapiService } from './strapiService';
+import strapi from './strapi';
+
+jest.mock('./strapi');
+
+afterEach(() => {
+  (strapi.post as jest.Mock).mockClear();
+});
+
+test('getCollection calls strapi.post with GET method', async () => {
+  (strapi.post as jest.Mock).mockResolvedValue({ data: [] });
+  await strapiService.getCollection('users');
+  expect(strapi.post).toHaveBeenCalledWith({ method: 'GET', collection: 'users', query: undefined });
+});

--- a/src/services/strapiService.ts
+++ b/src/services/strapiService.ts
@@ -1,0 +1,11 @@
+import strapi from './strapi';
+
+export async function getCollection<T = any>(collection: string, query?: any) {
+  return strapi.post({ method: 'GET', collection, query });
+}
+
+export const strapiService = {
+  getCollection,
+};
+
+export default strapiService;


### PR DESCRIPTION
## Summary
- add strapiService wrapper
- implement `useUser` and `useStrapiSchema` hooks
- create tests for new hooks and service
- enhance finance dashboard page with dynamic forms and tables
- export form and table types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e600d2548325aed8d8023e05ed67