### PR TITLE
Fix finance dashboard layout imports

### DIFF
--- a/src/modules/finance-dashboard/routes/page.tsx
+++ b/src/modules/finance-dashboard/routes/page.tsx
@@ -1,13 +1,14 @@
-'use client';
-import React, { useState } from 'react';
-import Link from 'next/link';
-import { ThemeProvider, AppShellLayout } from '@k2600x/design-system';
-import { useUser } from '../hooks/useUser';
-import { useStrapiSchema } from '../hooks/useStrapiSchema';
-import { useStrapiCollection } from '../hooks/useStrapiCollection';
-import { useStrapiForm } from '../hooks/useStrapiForm';
-import { SmartDataTable } from '../components/SmartDataTable';
-import { DynamicForm } from '../components/DynamicForm';
+"use client";
+import React, { useState } from "react";
+import Link from "next/link";
+import { ThemeProvider } from "@k2600x/design-system";
+import { AppShellLayout } from "@/components/layout";
+import { useUser } from "../hooks/useUser";
+import { useStrapiSchema } from "../hooks/useStrapiSchema";
+import { useStrapiCollection } from "../hooks/useStrapiCollection";
+import { useStrapiForm } from "../hooks/useStrapiForm";
+import { SmartDataTable } from "../components/SmartDataTable";
+import { DynamicForm } from "../components/DynamicForm";
 
 export default function FinanceDashboardPage() {
   const { user, loading: userLoading } = useUser();
@@ -17,7 +18,7 @@ export default function FinanceDashboardPage() {
       <div className="flex flex-col items-center justify-center h-full">
         <p className="mb-4">Debes iniciar sesión para acceder al admin.</p>
         <button
-          onClick={() => (window.location.href = '/admin')}
+          onClick={() => (window.location.href = "/admin")}
           className="px-4 py-2 bg-primary text-white rounded"
         >
           Ir a Login
@@ -26,25 +27,45 @@ export default function FinanceDashboardPage() {
     );
   }
 
-  const { schemas, loading: schemasLoading, error: schemasError } = useStrapiSchema();
-  const [model, setModel] = useState<string>('');
+  const {
+    schemas,
+    loading: schemasLoading,
+    error: schemasError,
+  } = useStrapiSchema();
+  const [model, setModel] = useState<string>("");
   if (schemasLoading) return <div>Cargando esquemas...</div>;
-  if (schemasError || schemas.length === 0) return <div>Error al cargar esquemas</div>;
+  if (schemasError || schemas.length === 0)
+    return <div>Error al cargar esquemas</div>;
   if (!model) setModel(schemas[0].uid);
 
   const { data, columns, pagination, refetch } = useStrapiCollection(model);
-  const { schema, defaultValues, fields, onSubmit } = useStrapiForm(model, 'update');
+  const { schema, defaultValues, fields, onSubmit } = useStrapiForm(
+    model,
+    "update",
+  );
 
   return (
-    <ThemeProvider initialTheme="futuristic">
-      <AppShellLayout title="Admin v2: Dynamic Collections" theme="futuristic">
+    <ThemeProvider>
+      <AppShellLayout navbarItems={[]} sidebarItems={[]}>
         <div className="p-4 space-y-6">
           <div className="flex space-x-4 mb-4">
-            <Link href="/admin" className="underline">Admin v1</Link>
-            <Link href="/admin/finance-dashboard" className="underline font-semibold">Admin v2</Link>
+            <Link href="/admin" className="underline">
+              Admin v1
+            </Link>
+            <Link
+              href="/admin/finance-dashboard"
+              className="underline font-semibold"
+            >
+              Admin v2
+            </Link>
           </div>
           <section>
-            <label htmlFor="collection-select" className="block mb-2 font-medium text-sm">Colección</label>
+            <label
+              htmlFor="collection-select"
+              className="block mb-2 font-medium text-sm"
+            >
+              Colección
+            </label>
             <select
               id="collection-select"
               className="p-2 border rounded"
@@ -63,7 +84,11 @@ export default function FinanceDashboardPage() {
             <SmartDataTable
               data={data}
               columns={columns}
-              pagination={pagination}
+              pagination={{
+                totalItems: pagination.total,
+                itemsPerPage: pagination.pageSize,
+                currentPage: pagination.page,
+              }}
               onPageChange={() => {}}
               onEdit={(row) => {
                 onSubmit(row);
@@ -75,8 +100,8 @@ export default function FinanceDashboardPage() {
           <section>
             <h2 className="text-lg font-semibold">Editar / Crear {model}</h2>
             <DynamicForm
-              schema={schema}
-              fields={fields}
+              schema={schema as any}
+              fields={fields as any}
               defaultValues={defaultValues}
               onSubmit={async (values) => {
                 await onSubmit(values);


### PR DESCRIPTION
## Summary
- fix `AppShellLayout` import to use local layout component
- update theme provider usage
- match pagination prop to data table
- cast dynamic form props

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857e8b37cb88325b209c6f9e43e2ebe